### PR TITLE
Always set both lopcutoff and hipcutoff when changing filter value

### DIFF
--- a/filta/dsp/dsp_filters.hxx
+++ b/filta/dsp/dsp_filters.hxx
@@ -79,17 +79,19 @@ class Filters // : Effect
         {
           float zeroOne = (value-0.5)*2.f;
           hipcutoff = 10 + pow(zeroOne,4) * 6000;
+          lopcutoff = fSamplingFreq / 2.0;
         }
         else
         {
           float zeroOne = (value)*2.f;
           lopcutoff = 100 + pow(zeroOne,4) * ((fSamplingFreq/2.f)-100);
+          hipcutoff = 10;
         }
       }
       else
       {
         hipcutoff = 10;
-        lopcutoff = 10000;
+        lopcutoff = fSamplingFreq / 2.0;
       }
     }
     


### PR DESCRIPTION
When doing fast changes of the filter frequency (from the gui) one could end up with a band-pass filter.
Also I set the lopcutoff to a more reasonable value when de-active.
