### PR TITLE
makes the benchmark binary optional, but defaults to on

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,5 +34,3 @@ artyfx_dsp = library('artyfx',
     install_dir : 'lib/lv2/artyfx.lv2/',
     dependencies: deps)
 
-# compile the benchmark
-#executable('artyfx_benchmark', ' ,dependencies: artyfx_dsp)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('benchmark', type:'boolean', value: true, description: 'Build the benchmark program.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('benchmark', type:'boolean', value: true, description: 'Build the benchmark program.')

--- a/src/dsp/meson.build
+++ b/src/dsp/meson.build
@@ -24,7 +24,9 @@ subdir('rr')
 sndfile = dependency('sndfile')
 pthreads = dependency('threads')
 
-if get_option('benchmark')
+gbench = dependency('benchmark', required: false)
+
+if gbench.found()
     gbench = dependency('benchmark')
     executable('artyfx_benchmark', artyfx_dsp_src + ['perf_test.cpp'],
         dependencies: [gbench, sndfile, pthreads])

--- a/src/dsp/meson.build
+++ b/src/dsp/meson.build
@@ -21,9 +21,11 @@ subdir('eq')
 subdir('rr')
 
 # compile the benchmark
-gbench = dependency('benchmark')
 sndfile = dependency('sndfile')
 pthreads = dependency('threads')
 
-executable('artyfx_benchmark', artyfx_dsp_src + ['perf_test.cpp'],
-    dependencies: [gbench, sndfile, pthreads])
+if get_option('benchmark')
+    gbench = dependency('benchmark')
+    executable('artyfx_benchmark', artyfx_dsp_src + ['perf_test.cpp'],
+        dependencies: [gbench, sndfile, pthreads])
+endif


### PR DESCRIPTION
Uses meson's compile options to allow building the plugin on systems that do not have or need the benchmark.

To preserve upstream's existing workflow, the setting defaults to behave the same as before this patch.

`meson .. -Dbenchmark=false` will however disable the dependency check and attempt to build the bench.