### PR TITLE
Fixing build for lv2 1.18.0

### DIFF
--- a/friza/gui/ui.cxx
+++ b/friza/gui/ui.cxx
@@ -46,7 +46,7 @@ typedef struct {
 	LV2UI_Controller controller;
 } GUI;
 
-LV2UI_Handle friza_instantiate(const struct _LV2UI_Descriptor * descriptor,
+LV2UI_Handle friza_instantiate(const struct LV2UI_Descriptor * descriptor,
                                const char * plugin_uri,
                                const char * bundle_path,
                                LV2UI_Write_Function write_function,

--- a/friza/gui/ui.hxx
+++ b/friza/gui/ui.hxx
@@ -18,7 +18,7 @@
  * MA 02110-1301, USA.
  */
 
-extern LV2UI_Handle friza_instantiate(const struct _LV2UI_Descriptor * descriptor,
+extern LV2UI_Handle friza_instantiate(const struct LV2UI_Descriptor * descriptor,
                                       const char * plugin_uri,
                                       const char * bundle_path,
                                       LV2UI_Write_Function write_function,

--- a/src/avtk/lv2/testUi.cxx
+++ b/src/avtk/lv2/testUi.cxx
@@ -10,7 +10,7 @@
 #include "../test_ui.hxx"
 
 
-static LV2UI_Handle avtk_instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle avtk_instantiate(const struct LV2UI_Descriptor * descriptor,
                                      const char * plugin_uri,
                                      const char * bundle_path,
                                      LV2UI_Write_Function write_function,

--- a/src/ui/lv2_ui.cxx
+++ b/src/ui/lv2_ui.cxx
@@ -33,7 +33,7 @@
 #include "whaaa.hxx"
 
 
-static LV2UI_Handle artyfx_instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle artyfx_instantiate(const struct LV2UI_Descriptor * descriptor,
                                        const char * plugin_uri,
                                        const char * bundle_path,
                                        LV2UI_Write_Function write_function,


### PR DESCRIPTION
Replacing all instances of _LV2UI_Descriptor with LV2UI_Descriptor,
which was a breaking change introduced in lv2 1.18.0.

Closes #40