### PR TITLE
Fix building on macOS and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,10 @@ pkg_check_modules(SND sndfile REQUIRED)
 include_directories( ${SND_INCLUDE_DIRS}  )
 #target_link_libraries( avtkDemo ${CAIRO_LIBRARIES}  )
 
-SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fPIC -shared -L./src/avtk -Wl,--no-undefined")
+SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fPIC -shared -L./src/avtk")
+if(NOT APPLE)
+  SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+endif()
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -O1 -Wno-unused-variable")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -O1 -Wno-unused-variable -ftree-vectorize")
 

--- a/src/dsp/artyfx.cxx
+++ b/src/dsp/artyfx.cxx
@@ -49,6 +49,7 @@ static const LV2_Descriptor descriptors[] = {
 		Bitta::cleanup,
 		Bitta::extension_data
 	},
+#ifndef _WIN32
 	{
 		CAPTA_URI,
 		Capta::instantiate,
@@ -59,6 +60,7 @@ static const LV2_Descriptor descriptors[] = {
 		Capta::cleanup,
 		Capta::extension_data
 	},
+#endif
 	{
 		DELLA_URI,
 		Della::instantiate,

--- a/src/dsp/capta.cxx
+++ b/src/dsp/capta.cxx
@@ -29,6 +29,8 @@
 #include <sstream>
 #include <sndfile.hh>
 
+#ifndef _WIN32
+
 LV2_Handle Capta::instantiate(const LV2_Descriptor* descriptor,
                               double samplerate,
                               const char* bundle_path,
@@ -207,3 +209,4 @@ const void* Capta::extension_data(const char* uri)
 	return NULL;
 }
 
+#endif

--- a/src/dsp/capta.hxx
+++ b/src/dsp/capta.hxx
@@ -45,6 +45,8 @@ typedef enum {
 #include "zix/sem.h"
 #include "zix/thread.h"
 
+#ifndef _WIN32
+
 class SndfileHandle;
 
 class Capta
@@ -100,5 +102,7 @@ private:
 		return 0;
 	}
 };
+
+#endif
 
 #endif // OPENAV_CAPTA

--- a/src/dsp/driva.hxx
+++ b/src/dsp/driva.hxx
@@ -26,22 +26,22 @@
 #define DRIVA_URI    "http://www.openavproductions.com/artyfx#driva"
 #define DRIVA_UI_URI "http://www.openavproductions.com/artyfx#driva/gui"
 
-typedef enum {
-	// Audio
-	INPUT = 0,
-	OUTPUT,
-
-	// Top signal
-	DRIVA_TONE,
-	DRIVA_AMOUNT,
-
-} DrivaPortIndex;
-
 class StompBox;
 
 class Driva
 {
 public:
+	typedef enum {
+		// Audio
+		INPUT = 0,
+		OUTPUT,
+
+		// Top signal
+		DRIVA_TONE,
+		DRIVA_AMOUNT,
+
+	} DrivaPortIndex;
+
 	Driva(int rate);
 	~Driva();
 	static LV2_Handle instantiate(const LV2_Descriptor* descriptor,


### PR DESCRIPTION
So the plugins work on these systems.

The ttl still has `*.so` hardcoded, but I dont know cmake well enough to understand how to achieve this.
