### PR TITLE
Add missing semicolon

### DIFF
--- a/src/dsp/perf_test.cpp
+++ b/src/dsp/perf_test.cpp
@@ -136,4 +136,4 @@ BENCHMARK(masher    )->Range(8, 1024);
 BENCHMARK(filters   )->Range(8, 1024);
 BENCHMARK(wah       )->Range(8, 1024);
 
-BENCHMARK_MAIN()
+BENCHMARK_MAIN();


### PR DESCRIPTION
At least with recent versions of libbenchmark, `BENCHMARK_MAIN()` needs a semicolon afterward, as [its definition](https://github.com/google/benchmark/blob/4682db08bc7bb7e547e0a1056e32392998f8101f/include/benchmark/benchmark.h#L1665) ends with `int main(int, char**)` with no semicolon.