### PR TITLE
Fix SSE flags for RISC-V and respect BUILD_SSE option

### DIFF
--- a/src/avtk/CMakeLists.txt
+++ b/src/avtk/CMakeLists.txt
@@ -54,13 +54,16 @@ pkg_check_modules(X11 x11 REQUIRED)
 include_directories( ${X11_INCLUDE_DIRS} )
 link_directories   ( ${X11_LIBRARY_DIRS} )
 
-IF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+IF(BUILD_SSE AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "riscv")
   SET(CMAKE_C_FLAGS   "-fPIC -msse -msse2 -mfpmath=sse -g") # -fsanitize=address
   SET(CMAKE_CXX_FLAGS "-fPIC -msse -msse2 -mfpmath=sse -g") # -fsanitize=address
-ELSE()
+ELSEIF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
     SET(CMAKE_C_FLAGS   "-fPIC -mfpu=neon -g")
     SET(CMAKE_CXX_FLAGS "-fPIC -mfpu=neon -g")
-ENDIF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+ELSE()
+    SET(CMAKE_C_FLAGS   "-fPIC -g")
+    SET(CMAKE_CXX_FLAGS "-fPIC -g")
+ENDIF()
 
 FILE(GLOB src libs/pffft.cxx avtk/*.cxx )
 


### PR DESCRIPTION
## Summary
- Fix SSE flags in `src/avtk/CMakeLists.txt` to respect the `BUILD_SSE` option
- Add RISC-V architecture check to prevent SSE flags on RISC-V systems
- Add fallback case for architectures without SSE or NEON support

## Details
The `src/avtk/CMakeLists.txt` was unconditionally adding `-msse -msse2 -mfpmath=sse` flags for non-ARM processors, even when `BUILD_SSE=OFF` was set. This caused build failures on RISC-V systems.

The fix ensures that:
1. SSE flags are only added when `BUILD_SSE` is enabled (from parent CMakeLists.txt)
2. SSE flags are never added on ARM or RISC-V architectures
3. ARM systems get NEON flags
4. Other architectures (including RISC-V) get basic flags without SSE

## Verification
- Tested that the logic correctly handles all architecture cases
- The change is minimal and only affects the flag selection logic in avtk/CMakeLists.txt

Fixes #47
